### PR TITLE
update Android JPush SDK GooglePlay Version link.

### DIFF
--- a/zh/jpush/resources.md
+++ b/zh/jpush/resources.md
@@ -12,7 +12,7 @@
                     <li><a href="../client/Android/android_guide">集成指南</a></li>
                     <li><a href="../client/Android/android_3m">3 分钟快速 Demo</a></li>
                     <li><a href="../client/Android/android_debug_guide">调试指南</a></li>
-                    <li><a href="https://sdkfiledl.jiguang.cn/src/jpush-android-3.1.2-google_play.zip?v1523513207682">Google Play 版本</a></li>
+                    <li><a href="https://sdkfiledl.jiguang.cn/src/jpush-android-3.1.3-google_play.zip">Google Play 版本</a></li>
                 </ul>
                 <p><a href="https://www.jiguang.cn/downloads/sdk/android" class="btn btn-default" role="button">下载</a></p>
             </div>


### PR DESCRIPTION
更新 Android JPush SDK 3.1.3 google play 版本的链接。