### PR TITLE
1. 最新更新页面，针对JPush Android SDK v3.2.0 和JPush Android SDK v3.1.8版本更新说明需…

### DIFF
--- a/zh/jpush/client/Android/android_guide.md
+++ b/zh/jpush/client/Android/android_guide.md
@@ -130,8 +130,8 @@
         dependencies {
             ......
 
-            compile 'cn.jiguang.sdk:jpush:3.1.6'  // 此处以JPush 3.1.6 版本为例。
-            compile 'cn.jiguang.sdk:jcore:1.2.5'  // 此处以JCore 1.2.5 版本为例。
+            compile 'cn.jiguang.sdk:jpush:3.2.0'  // 此处以JPush 3.2.0 版本为例。
+            compile 'cn.jiguang.sdk:jcore:1.2.7'  // 此处以JCore 1.2.7 版本为例。
             ......
         }
 

--- a/zh/jpush/updates.md
+++ b/zh/jpush/updates.md
@@ -18,7 +18,7 @@
 + 首先解压您获取到的 zip 压缩包
 
 + 更新库文件
-	+ 打开 libs 文件夹。用 jpush-android-3.x.y.jar 和 jcore-android-1.x.y.jar 替换项目中原有的极光 jar 文件，并删除原有极光 jar 文件。用对应 CPU 文件夹下的 libjcorexxx.so 文件，替换项目中原有的 libjpushXXX.so 文件，并删除原有的极光 so 文件，每种型号的 so 文件都可以在 SDK 下载包中找到。
+	+ 打开 libs 文件夹。用 jpush-android-3.2.0.jar 和 jcore-android-1.2.7.jar 替换项目中原有的极光 jar 文件，并删除原有极光 jar 文件。用对应 CPU 文件夹下的 libjcorexxx.so 文件，替换项目中原有的 libjpushXXX.so 文件，并删除原有的极光 so 文件，每种型号的 so 文件都可以在 SDK 下载包中找到。
 
 + 更新 AndroidManifest.xml
 	+ 请对照示例 AndroidManifest 更新 JPush 相关的组件属性，Permission，Action 等配置。并在中文提示的位置替换你的包名 和 appkey。
@@ -84,7 +84,7 @@
 + 首先解压您获取到的 zip 压缩包
 
 + 更新库文件
-	+ 打开 libs 文件夹。用 jpush-android-3.x.y.jar 和 jcore-android-1.x.y.jar 替换项目中原有的极光 jar 文件，并删除原有极光 jar 文件。用对应 CPU 文件夹下的 libjcorexxx.so 文件，替换项目中原有的 libjpushXXX.so 文件，并删除原有的极光 so 文件，每种型号的 so 文件都可以在 SDK 下载包中找到。
+	+ 打开 libs 文件夹。用 jpush-android-3.1.8.jar 和 jcore-android-1.2.6.jar 替换项目中原有的极光 jar 文件，并删除原有极光 jar 文件。用对应 CPU 文件夹下的 libjcore126.so 文件，替换项目中原有的 libjpushXXX.so 文件，并删除原有的极光 so 文件，每种型号的 so 文件都可以在 SDK 下载包中找到。
 
 + 更新 AndroidManifest.xml
 	+ 请对照示例 AndroidManifest 更新 JPush 相关的组件属性，Permission，Action 等配置。并在中文提示的位置替换你的包名 和 appkey。


### PR DESCRIPTION
…要的jar和so文件详细说明

2. Android SDK 集成指南页面，针对jcenter 自动集成步骤里面涉及的依赖jar包版本改成目前已有的最新版本